### PR TITLE
rewrite security rules

### DIFF
--- a/security.tf
+++ b/security.tf
@@ -7,92 +7,120 @@ resource "azurerm_network_security_group" "sg" {
   name                = local.net-name
   location            = var.location
   resource_group_name = azurerm_resource_group.resource.name
+  tags                = merge({ Name = "${local.net-name}" }, var.common-tags)
+}
 
-  security_rule {
-    name                       = "SSH"
-    priority                   = 1001
-    direction                  = "Inbound"
-    access                     = "Allow"
-    protocol                   = "Tcp"
-    source_port_range          = "*"
-    destination_port_range     = "22"
-    source_address_prefix      = "${chomp(data.http.myip.body)}/32"
-    destination_address_prefix = "*"
-  }
+resource "azurerm_network_security_rule" "install-ssh" {
+  name                        = "SSH-rule"
+  priority                    = 2001
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_range      = "22"
+  source_address_prefix       = "${chomp(data.http.myip.body)}/32"
+  destination_address_prefix  = "*"
+  resource_group_name         = azurerm_resource_group.resource.name
+  network_security_group_name = azurerm_network_security_group.sg.name
+}
 
-  security_rule {
-    name                       = "HTTPS-UI"
-    priority                   = 1000
-    direction                  = "Inbound"
-    access                     = "Allow"
-    protocol                   = "Tcp"
-    source_port_range          = "*"
-    destination_port_range     = "8443"
-    source_address_prefix      = "*"
-    destination_address_prefix = "*"
-  }
+resource "azurerm_network_security_rule" "https-ui" {
+  name                        = "HTTPS-UI-rule"
+  priority                    = 2000
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_range      = "8443"
+  source_address_prefix       = "*"
+  destination_address_prefix  = "*"
+  resource_group_name         = azurerm_resource_group.resource.name
+  network_security_group_name = azurerm_network_security_group.sg.name
+}
 
-  security_rule {
-    name                       = "HTTPS-API"
-    priority                   = 1100
-    direction                  = "Inbound"
-    access                     = "Allow"
-    protocol                   = "Tcp"
-    source_port_range          = "*"
-    destination_port_range     = "9443"
-    source_address_prefix      = "*"
-    destination_address_prefix = "*"
-  }
+resource "azurerm_network_security_rule" "https-api" {
+  name                        = "HTTPS-API-rule"
+  priority                    = 2100
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_range      = "9443"
+  source_address_prefix       = "*"
+  destination_address_prefix  = "*"
+  resource_group_name         = azurerm_resource_group.resource.name
+  network_security_group_name = azurerm_network_security_group.sg.name
+}
 
 
-  security_rule {
-    name                       = "DBs"
-    priority                   = 1009
-    direction                  = "Inbound"
-    access                     = "Allow"
-    protocol                   = "Tcp"
-    source_port_range          = "*"
-    destination_port_range     = "10001-19999"
-    source_address_prefix      = "${chomp(data.http.myip.body)}/32"
-    destination_address_prefix = "*"
-  }
+resource "azurerm_network_security_rule" "redis-dbs" {
+  name                        = "DBs-rule"
+  priority                    = 2009
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_range      = "10001-19999"
+  source_address_prefix       = "${chomp(data.http.myip.body)}/32"
+  destination_address_prefix  = "*"
+  resource_group_name         = azurerm_resource_group.resource.name
+  network_security_group_name = azurerm_network_security_group.sg.name
+}
 
-  security_rule {
-    name                       = "DB-Sentinel"
-    priority                   = 1006
-    direction                  = "Inbound"
-    access                     = "Allow"
-    protocol                   = "Tcp"
-    source_port_range          = "*"
-    destination_port_range     = "8001"
-    source_address_prefix      = "*"
-    destination_address_prefix = "*"
-  }
+resource "azurerm_network_security_rule" "redis-sentinel" {
+  name                        = "DB-Sentinel-rule"
+  priority                    = 2006
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_range      = "8001"
+  source_address_prefix       = "*"
+  destination_address_prefix  = "*"
+  resource_group_name         = azurerm_resource_group.resource.name
+  network_security_group_name = azurerm_network_security_group.sg.name
+}
 
-  # security_rule {
-  #   name                       = "Prometheus"
-  #   priority                   = 1007
-  #   direction                  = "Inbound"
-  #   access                     = "Allow"
-  #   protocol                   = "Tcp"
-  #   source_port_range          = "*"
-  #   destination_port_range     = "8070"
-  #   source_address_prefix      = "*"
-  #   destination_address_prefix = "*"
-  # }
+resource "azurerm_network_security_rule" "dns-services" {
+  name                        = "DNS-Server-rule"
+  priority                    = 2027
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "Udp"
+  source_port_range           = "*"
+  destination_port_range      = "53"
+  source_address_prefix       = "*"
+  destination_address_prefix  = "*"
+  resource_group_name         = azurerm_resource_group.resource.name
+  network_security_group_name = azurerm_network_security_group.sg.name
+}
 
-  security_rule {
-    name                       = "DNS-Server"
-    priority                   = 1027
-    direction                  = "Inbound"
-    access                     = "Allow"
-    protocol                   = "Udp"
-    source_port_range          = "*"
-    destination_port_range     = "53"
-    source_address_prefix      = "*"
-    destination_address_prefix = "*"
-  }
+resource "azurerm_network_security_rule" "public-ssh" {
+  count                       = var.allow-public-ssh
+  name                        = "Public-SSH-rule"
+  priority                    = 2028
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_range      = "22"
+  source_address_prefix       = "*"
+  destination_address_prefix  = "*"
+  resource_group_name         = azurerm_resource_group.resource.name
+  network_security_group_name = azurerm_network_security_group.sg.name
+}
 
-  tags = merge({ Name = "${local.net-name}" }, var.common-tags)
-
+resource "azurerm_network_security_rule" "open-nets" {
+  count                       = length(var.open-nets)
+  name                        = "Open-Net-${count.index}"
+  priority                    = "${format("%02d", count.index+3000)}"
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "*"
+  source_port_range           = "*"
+  destination_port_range      = "*"
+  source_address_prefix       = "${element(var.open-nets, count.index)}"
+  destination_address_prefix  = "*"
+  resource_group_name         = azurerm_resource_group.resource.name
+  network_security_group_name = azurerm_network_security_group.sg.name
 }

--- a/test/main.tf
+++ b/test/main.tf
@@ -2,9 +2,11 @@ provider "azurerm" {
 }
 
 module "azure" {
-  source       = "../"
-  location     = "us2west" # broken on purpose so you can't create resoruces
-  cluster-name = "terraform-test-1.azure.example.com"
+  source           = "../"
+  location         = "us2west" # broken on purpose so you can't create resoruces
+  cluster-name     = "terraform-test-1.azure.example.com"
+  allow-public-ssh = 1
+  open-nets        = ["10.0.0.12/32"]
   common-tags = {
     Owner       = "Ken_Watanabe@example.com",
     Config      = "terraform",

--- a/variables.tf
+++ b/variables.tf
@@ -94,3 +94,15 @@ variable "re-download-url" {
   description = "The download link for the redis enterprise software"
   default     = null
 }
+
+variable "allow-public-ssh" {
+  description = "Allow SSH to be open to the public - disabled by default"
+  default     = "0"
+}
+
+variable "open-nets" {
+  type        = list
+  description = "CIDRs that will have access to everything"
+  default     = []
+}
+


### PR DESCRIPTION
Move rules out from inline so we can add open-nets and be able to enable/disable public ssh access